### PR TITLE
Feature/performance design

### DIFF
--- a/absolventa/absolventa_xml.md
+++ b/absolventa/absolventa_xml.md
@@ -41,8 +41,8 @@
   <tasks>
     <![CDATA[
       <ul>
-        <li>Du peppst die rauhen und kantigen Geschichten unserer weltweit verstreuten Mitarbeiter gekonnt linguistisch auf</li>
-        <li>Dein Instikt lässt dich problemlos Fakten von Seemannsgarn unterscheiden</li>
+        <li>Du peppst die rauhen und kantigen Geschichten unserer weltweit verstreuten Mitarbeiter linguistisch gekonnt auf</li>
+        <li>Dein Instikt lässt dich spielerisch prüfbare Fakten von hanebüchenem Seemannsgarn unterscheiden</li>
       </ul>
     ]]>
   </tasks>
@@ -84,7 +84,6 @@
   <use_responsive_template>true</use_responsive_template>
   <height>1234</height>
 
-  <!-- The submission of these fields is deprecated - please use <contact> instead! -->
   <contact_name>Elaine Marley</contact_name>
   <contact_email>elaine.marley@absolventa.de</contact_email>
   <contact_phone>+49 0123456</contact_phone>
@@ -256,7 +255,6 @@
       <td>String</td>
       <td>optional</td>
     </tr>
-
     <tr>
       <td>application_method</td>
       <td>Info about the application method.</td>

--- a/absolventa/absolventa_xml.md
+++ b/absolventa/absolventa_xml.md
@@ -1,38 +1,92 @@
 # Absolventa XML
 
 ```XML
+<?xml version="1.0" encoding="UTF-8"?>
 <job_offer>
+  <title>Praktikum Seefahrt (w/m/d)</title>
   <mode>premium</mode>
-  <title>Trainee Web Development (m/w)</title>
-  <external_url>https://example.com/jobs/1</external_url>
-  <description><![CDATA[<p>Basic HTML tags are allowed here</p>]]></description>
-  <started_at type="datetime">2017-01-03T00:00:00+02:00</started_at>
-  <ended_at type="datetime">2017-12-10T12:14:42+01:00</ended_at>
-  <!-- You need to either provide an URL or an email address for application. -->
-  <application_method>email/url</application_method>
-  <application_url>https://example.com/jobs/1/apply</application_url>
-  <application_email>application@absolventa.de</application_email>
-  <job_offer_locations>
-    <job_offer_location>
-      <street>Friedrichstraße 67</street>
-      <zip>10117</zip>
-      <city>Berlin</city>
-      <country>Deutschland</country>
-    </job_offer_location>
-    <job_offer_location>
-      <street>Greifswalder Straße 212</street>
-      <zip>10405</zip>
-      <city>Berlin</city>
-      <country>Deutschland</country>
-    </job_offer_location>
-  </job_offer_locations>
-  <contact_name>Rosi Beckers</contact_name>
-  <contact_email>rosi.beckers@absolventa.de</contact_email>
-  <contact_phone>030240483121</contact_name>
-  <contact_position>Leitung Personalwesen</contact_position>
-  <trainee_gefluester>true</trainee_gefluester>
+
+  <external_url><![CDATA[https://www.example.com/jobs/seefahrt]]></external_url>
+  <application_email>elaine.marley@absolventa.de</application_email>
+  <application_url><![CDATA[https://www.example.com/jobs/seefahrt/apply]]></application_url>
+  <started_at>2019-11-11T13:14:40+01:00</started_at>
+  <ended_at>2019-11-15T23:59:59+01:00</ended_at>
+
+  <city>Berlin</city>
+  <street>Friedrichstraße 67</street>
+  <zip>10318</zip>
+  <country>Deutschland</country>
+
+  <description_headline>Komm' an Bord!</description_headline>
+  <description>
+    <![CDATA[
+      <p>
+        Unser renormiertes Seefahrtsunternehmen heuert verlässlich und regelmäßig die besten
+        Seefrauen und -männer (w/m/d) östlich des Atlantiks an. Generationen von Seefahrtsexperten
+        haben ihre Karriere mit ersten nautischen Schritten in unserem Unternehmen gestartet.
+      </p>
+    ]]>
+  </description>
+
+  <qualifications_headline>Du bist mutig genug, in allen Ozeanen dieser Welt zu schwimmen?</qualifications_headline>
+  <qualifications>
+    <![CDATA[
+      <ul>
+        <li>Du kannst schwimmen (Seepferdchen notwendig)</li>
+        <li>Ein leichtes Schaukeln ist für dich kein Problem</li>
+      </ul>
+    ]]>
+  </qualifications>
+
+  <tasks_headline>Du kannst im Schlaf unter tosendem Sturm problemlos Segel setzen?</tasks_headline>
+  <tasks>
+    <![CDATA[
+      <ul>
+        <li>Du peppst die rauhen und kantigen Geschichten unserer weltweit verstreuten Mitarbeiter gekonnt linguistisch auf</li>
+        <li>Dein Instikt lässt dich problemlos Fakten von Seemannsgarn unterscheiden</li>
+      </ul>
+    ]]>
+  </tasks>
+
+  <benefits_headline>Bestens ausgerüstet!</benefits_headline>
+  <benefits>
+    <![CDATA[
+      <ul>
+        <li>Reise zum Ende der Welt</li>
+        <li>Ein loyales Team</li>
+        <li>Remote first: Wir begrüßen ausdrücklich das eigenständige, asynchrone Arbeiten in entlegenen Gegenden</li>
+      </ul>
+    ]]>
+  </benefits>
+
+  <company_description_headline>Unser Geschäft ist kein Voodoo!</company_description_headline>
+  <company_description>
+    <![CDATA[
+      <p>Marley & Threepwood Ventures - Ihr Partner in Sachen Seefahrt- und Handelsbeziehungen</p>
+    ]]>
+  </company_description>
+
+  <video_url><![CDATA[https://api.example.com/videos/seemannsgarn]]></video_url>
+  <header_image_url><![CDATA[https://api.example.com/content/header_image.jpg]]></header_image_url>
+
+  <contact_headline>Frag' unsere Expertin Elaine!</contact_headline>
+  <contact>
+    <![CDATA[
+      <p>Elaine Marley</p>
+      <p>elaine.marley@absolventa.de</p>
+      <small>Senior Seefahrt-Personalmanagerin</small>
+    ]]>
+  </contact>
+
   <use_responsive_template>true</use_responsive_template>
-  <height>1200</height>
+  <height>1234</height>
+  <color>#efefef</color>
+
+  <!-- The submission of these fields is deprecated -->
+  <contact_name>Elaine Marley</contact_name>
+  <contact_email>elaine.marley@absolventa.de</contact_email>
+  <contact_phone>+49 0123456</contact_phone>
+  <contact_position>Recruiter</contact_position>
 </job_offer>
 ```
 

--- a/absolventa/absolventa_xml.md
+++ b/absolventa/absolventa_xml.md
@@ -6,7 +6,6 @@
   <title>Praktikum Seefahrt (w/m/d)</title>
   <mode>premium</mode>
 
-  <external_url><![CDATA[https://www.example.com/jobs/seefahrt]]></external_url>
   <application_email>elaine.marley@absolventa.de</application_email>
   <application_url><![CDATA[https://www.example.com/jobs/seefahrt/apply]]></application_url>
   <started_at>2019-11-11T13:14:40+01:00</started_at>
@@ -78,11 +77,14 @@
     ]]>
   </contact>
 
-  <use_responsive_template>true</use_responsive_template>
-  <height>1234</height>
   <color>#efefef</color>
 
-  <!-- The submission of these fields is deprecated -->
+  <!-- These XML fields are deprecated -->
+  <external_url><![CDATA[https://www.example.com/jobs/seefahrt]]></external_url>
+  <use_responsive_template>true</use_responsive_template>
+  <height>1234</height>
+
+  <!-- The submission of these fields is deprecated - please use <contact> instead! -->
   <contact_name>Elaine Marley</contact_name>
   <contact_email>elaine.marley@absolventa.de</contact_email>
   <contact_phone>+49 0123456</contact_phone>
@@ -111,7 +113,7 @@
     <tr>
       <td>mode</td>
       <td>
-        Possible values: <code>standard</code> and <code>premium</code>.
+        Possible values: <code>standard</code>. <code>premium</code> and <code>premium_plus</code>.
         Defaults to <code>standard</code> if omitted.
         Cannot be changed after creation.
       </td>
@@ -134,14 +136,74 @@
       <td>optional</td>
     </tr>
     <tr>
+      <td>description_headline</td>
+      <td>Headline summarizing the introductory description-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
       <td>description</td>
       <td>Description text of your job ad. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
       <td>Text</td>
       <td>required</td>
     </tr>
     <tr>
+      <td>company_description_headline</td>
+      <td>Headline summarizing the company_description-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
       <td>company_description</td>
       <td>Description text of your company. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>qualifications_headline</td>
+      <td>Headline summarizing the introductory qualifications-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>qualifications</td>
+      <td>Text summarizing the requirements of the candiates. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>tasks_headline</td>
+      <td>Headline summarizing the tasks-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>tasks</td>
+      <td>Text summarizing the job tasks of the candiates. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>benefits_headline</td>
+      <td>Headline summarizing the benefits-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>benefits</td>
+      <td>Text summarizing the job benefits of the candiates. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>contact_headline</td>
+      <td>Headline summarizing the contact-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>contact</td>
+      <td>Text summarizing the contact information for the candiates. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
       <td>Text</td>
       <td>optional</td>
     </tr>
@@ -157,7 +219,7 @@
     </tr>
     <tr>
       <td>apprenticeship_started_at</td>
-      <td>Date on which the apprenticeship will start</td>
+      <td>Date on which the apprenticeship will start. Only relevant for job ads targeted at https://www.azubi.de.</td>
       <td>Datetime</td>
       <td>optional</td>
     </tr>
@@ -176,6 +238,16 @@
       <td>String</td>
       <td>optional</td>
     </tr>
+    <tr>
+      <td>praktikum_info</td>
+      <td>
+        <p>Allows co-publication a job offer on our job board PRAKTIKUM.INFO by supplying <code>true</code> (valid PRAKTIKUM.INFO contract required).</p>
+        <p>Contact your account manager if you are interested in this service.</p>
+      </td>
+      <td>String</td>
+      <td>optional</td>
+    </tr>
+
     <tr>
       <td>application_method</td>
       <td>Info about the application method.</td>

--- a/absolventa/absolventa_xml.md
+++ b/absolventa/absolventa_xml.md
@@ -127,15 +127,6 @@
       <td>required</td>
     </tr>
     <tr>
-      <td>external_url</td>
-      <td>
-        URL pointing to a HTML representation of your job offer. The HTML content of the <code>external_url</url> will be
-        displayed within an <code>iframe</code> element on our website.
-      </td>
-      <td>String</td>
-      <td>optional</td>
-    </tr>
-    <tr>
       <td>description_headline</td>
       <td>Headline summarizing the introductory description-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
       <td>Text</td>
@@ -208,6 +199,24 @@
       <td>optional</td>
     </tr>
     <tr>
+      <td>video_url</td>
+      <td>URL to embeddable video content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>header_image_url</td>
+      <td>URL to image that is being displayed at the top of the job ad. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>color</td>
+      <td>Hex code for headline color. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
       <td>started_at</td>
       <td>
         Date the job offer starts being published to our platform. Note that once the job offer has
@@ -273,24 +282,6 @@
         has to include at least a <code>city</code> and a <code>zip</code> value.
       </td>
       <td>job_offer_location object</td>
-      <td>optional</td>
-    </tr>
-    <tr>
-      <td>use_responsive_template</td>
-      <td>
-        If you also submit an HTML representation of the job_offer (by submission of
-        <code>external_url</code>) and if your HTML representation behaves responsive, you
-        can set this attribute to <code>true</code>. In this case the iframe serving
-        your HTML content will be displayed for mobile devices, too. If left out or
-        set to false, we will always render a text representation of the job offer.
-      </td>
-      <td>Boolean</td>
-      <td>optional</td>
-    </tr>
-    <tr>
-      <td>height</td>
-      <td>Height of the iframe displaying the content of <code>external_url</code> in px.</td>
-      <td>Integer</td>
       <td>optional</td>
     </tr>
   </tbody>

--- a/absolventa/absolventa_xml.md
+++ b/absolventa/absolventa_xml.md
@@ -16,6 +16,21 @@
   <zip>10318</zip>
   <country>Deutschland</country>
 
+  <job_offer_locations>
+    <job_offer_location>
+      <city>Berlin</city>
+      <street>Greifswalder Straße 212</street>
+      <zip>10405</zip>
+      <country>Deutschland</country>
+    </job_offer_location>
+    <job_offer_location>
+      <city>Berlin</city>
+      <street>Oranienburger Straße 33</street>
+      <zip>10178</zip>
+      <country>Deutschland</country>
+    </job_offer_location>
+  </job_offer_locations>
+
   <description_headline>Komm' an Bord!</description_headline>
   <description>
     <![CDATA[

--- a/absolventa/hr_xml.md
+++ b/absolventa/hr_xml.md
@@ -27,11 +27,22 @@
       <PhysicalLocation>
         <PostalAddress>
           <CountryCode>Deutschland</CountryCode>
-          <PostalCode>10318</PostalCode>
+          <PostalCode>10117</PostalCode>
           <Municipality>Berlin</Municipality>
           <DeliveryAddress>
-            <StreetName>Friedrichstraße </StreetName>
+            <StreetName>Friedrichstraße</StreetName>
             <BuildingNumber>67</BuildingNumber>
+          </DeliveryAddress>
+        </PostalAddress>
+      </PhysicalLocation>
+      <PhysicalLocation>
+        <PostalAddress>
+          <CountryCode>Deutschland</CountryCode>
+          <PostalCode>10405</PostalCode>
+          <Municipality>Berlin</Municipality>
+          <DeliveryAddress>
+            <StreetName>Greifswalder Straße</StreetName>
+            <BuildingNumber>212</BuildingNumber>
           </DeliveryAddress>
         </PostalAddress>
       </PhysicalLocation>

--- a/absolventa/hr_xml.md
+++ b/absolventa/hr_xml.md
@@ -1,73 +1,165 @@
 # HR-XML
 
 ```XML
-<PositionOpening>
- <PositionPostings>
-   <PositionPosting>
-     <Id validFrom="2017-01-03" validTo="2017-12-10">
-       <!-- Note that the ID is auto-assigned when using the RESTful API -->
-       <IdValue>12345</IdValue>
-     </Id>
-     <Link><![CDATA[https://example.com/jobs/1]]></Link>
-   </PositionPosting>
- </PositionPostings>
- <PositionProfile>
-   <PositionDetail>
-     <PhysicalLocation>
-       <PostalAddress>
-         <CountryCode>DE</CountryCode>
-         <PostalCode>10405</PostalCode>
-         <Municipality>Berlin</Municipality>
-         <DeliveryAddress>
-           <StreetName>Greifswader Straße</StreetName>
-           <BuildingNumber>212</BuildingNumber>
-         </DeliveryAddress>
-       </PostalAddress>
-     </PhysicalLocation>
-     <PhysicalLocation>
-       <PostalAddress>
-         <CountryCode>DE</CountryCode>
-         <PostalCode>10117</PostalCode>
-         <Municipality>Berlin</Municipality>
-         <DeliveryAddress>
-           <StreetName>Friedrichsstraße</StreetName>
-           <BuildingNumber>67</BuildingNumber>
-         </DeliveryAddress>
-       </PostalAddress>
-     </PhysicalLocation>
-     <PositionTitle><![CDATA[Trainee Web Development (m/w)]]></PositionTitle>
-   </PositionDetail>
-   <FormattedPositionDescription>
-     <Name>Mode</Name>
-     <Value>standard</Value>
-   </FormattedPositionDescription>
-   <FormattedPositionDescription>
-     <Name>CompanyDescription</Name>
-     <Value><![CDATA[<p>Basic HTML tags are allowed here</p>]]></Value>
-   </FormattedPositionDescription>
-   <FormattedPositionDescription>
-     <Name>JobOfferDescription</Name>
-     <Value>
-       <![CDATA[<p>Basic HTML tags are allowed here</p>]]>
-     </Value>
-   </FormattedPositionDescription>
-   <FormattedPositionDescription>
-     <Name>TraineeGefluester</Name>
-     <Value>1</Value>
-   </FormattedPositionDescription>
-   <FormattedPositionDescription>
-     <Name>UseResponsiveTemplate</Name>
-     <Value>true</Value>
-   </FormattedPositionDescription>
-   <FormattedPositionDescription>
-     <Name>Height</Name>
-     <Value>1234</Value>
-   </FormattedPositionDescription>
-   <HowToApply>
-     <ApplicationMethod>
-       <InternetWebAddress><![CDATA[https://example.com/jobs/1/apply]]></InternetWebAddress>
-     </ApplicationMethod>
-   </HowToApply>
+<?xml version='1.0' encoding='utf-8' ?>
+<PositionOpening xmlns:datetime='http://exslt.org/dates-and-times' xmlns:ns1='http://ns.hr-xml.org' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns='http://ns.hr-xml.org' xsi:schemaLocation='http://ns.hr-xml.org/2_4/HR-XML-2_4/StandAlone/PositionOpening.xsd'>
+  <PositionRecordInfo>
+    <Id idOwner='Scho GbR'>
+      <IdValue>2448257</IdValue>
+    </Id>
+  </PositionRecordInfo>
+  <PositionPostings>
+    <PositionPosting>
+      <Id validFrom='2019-11-11' validTo='2019-11-15'>
+        <IdValue>2448257</IdValue>
+      </Id>
+      <Link><![CDATA[]]></Link>
+    </PositionPosting>
+  </PositionPostings>
+  <UserArea>
+  </UserArea>
+  <PositionProfile xml:lang='DE'>
+    <PositionDateInfo></PositionDateInfo>
+    <PositionDetail>
+      <Company>
+        <Name>Scho GbR</Name>
+      </Company>
+      <PhysicalLocation>
+        <PostalAddress>
+          <CountryCode>Deutschland</CountryCode>
+          <PostalCode>10318</PostalCode>
+          <Municipality>Berlin</Municipality>
+          <DeliveryAddress>
+            <StreetName>Friedrichstraße </StreetName>
+            <BuildingNumber>67</BuildingNumber>
+          </DeliveryAddress>
+        </PostalAddress>
+      </PhysicalLocation>
+      <PositionTitle><![CDATA[Praktikum Seefahrt (w/m/d)]]></PositionTitle>
+    </PositionDetail>
+    <FormattedPositionDescription>
+      <Name>Mode</Name>
+      <Value>premium</Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>JobOfferDescription</Name>
+      <Value><![CDATA[<p>
+            Unser renormiertes Seefahrtsunternehmen heuert verlässlich und regelmäßig die besten
+            Seefrauen und -männer (w/m/d) östlich des Atlantiks an. Generationen von Seefahrtsexperten
+            haben ihre Karriere mit ersten nautischen Schritten in unserem Unternehmen gestartet.
+      </p>]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>JobOfferQualifications</Name>
+      <Value><![CDATA[<ul>
+          <li>Du kannst schwimmen (Seepferdchen notwendig)</li>
+          <li>Ein leichtes Schaukeln ist für dich kein Problem</li>
+      </ul>]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>CompanyDescriptionHeadline</Name>
+      <Value><![CDATA[Unser Geschäft ist kein Voodoo!]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>CompanyDescription</Name>
+      <Value><![CDATA[<p>Marley & Threepwood Ventures - Ihr Partner in Sachen Seefahrt- und Handelsbeziehungen</p>]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>DescriptionHeadline</Name>
+      <Value><![CDATA[Komm' an Bord!]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>Description</Name>
+      <Value><![CDATA[<p>
+            Unser renormiertes Seefahrtsunternehmen heuert verlässlich und regelmäßig die besten
+            Seefrauen und -männer (w/m/d) östlich des Atlantiks an. Generationen von Seefahrtsexperten
+            haben ihre Karriere mit ersten nautischen Schritten in unserem Unternehmen gestartet.
+      </p>]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>Qualifications</Name>
+      <Value><![CDATA[Du bist mutig genug, in allen Ozeanen dieser Welt zu schwimmen?]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>Qualifications</Name>
+      <Value><![CDATA[<ul>
+          <li>Du kannst schwimmen (Seepferdchen notwendig)</li>
+          <li>Ein leichtes Schaukeln ist für dich kein Problem</li>
+      </ul>]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>TasksHeadline</Name>
+      <Value><![CDATA[Du kannst im Schlaf unter tosendem Sturm problemlos Segel setzen?]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>Tasks</Name>
+      <Value><![CDATA[<ul>
+          <li>Du peppst die rauhen und kantigen Geschichten unserer weltweit verstreuten Mitarbeiter linguistisch gekonnt auf</li>
+          <li>Dein Instikt lässt dich spielerisch prüfbare Fakten von hanebüchenem Seemannsgarn unterscheiden</li>
+      </ul>]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>BenefitsHeadline</Name>
+      <Value><![CDATA[Bestens ausgerüstet!]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>Benefits</Name>
+      <Value><![CDATA[
+        <ul>
+          <li>Reise zum Ende der Welt</li>
+          <li>Ein loyales Team</li>
+          <li>Remote first: Wir begrüßen ausdrücklich das eigenständige, asynchrone Arbeiten in entlegenen Gegenden</li>
+      </ul>
+      ]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>ContactHeadline</Name>
+      <Value><![CDATA[Frag' unsere Expertin Elaine!]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>Contact</Name>
+      <Value><![CDATA[<p>Elaine Marley</p>
+        <p>elaine.marley@absolventa.de</p>
+        <small>Senior Seefahrt-Personalmanagerin</small>]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>VideoUrl</Name>
+      <Value><![CDATA[https://api.example.com/videos/seemannsgarn]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>Height</Name>
+      <Value><![CDATA[]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>UseResponsiveTemplate</Name>
+      <Value><![CDATA[]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>Color</Name>
+      <Value><![CDATA[#efefef]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>HeaderImageUrl</Name>
+      <Value><![CDATA[https://api.example.com/content/header_image.jpg]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>TraineeGefluester</Name>
+      <Value>false</Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>PraktikumInfo</Name>
+      <Value>false</Value>
+    </FormattedPositionDescription>
+    <HowToApply>
+      <ApplicationMethod>
+        <InternetWebAddress><![CDATA[https://www.example.com/jobs/seefahrt/apply]]></InternetWebAddress>
+      </ApplicationMethod>
+    </HowToApply>
+    <HowToApply>
+      <ApplicationMethod>
+        <InternetWebAddress><![CDATA[https://www.example.com/jobs/seefahrt/apply]]></InternetWebAddress>
+      </ApplicationMethod>
+    </HowToApply>
   </PositionProfile>
 </PositionOpening>
 ```
@@ -104,13 +196,6 @@
       <td>PositionTitle</td>
       <td>Title.</td>
       <td>String</td>
-      <td>required</td>
-    </tr>
-    <tr>
-      <td>JobOfferDescription</td>
-      <td>Description Text. Basic HTML tags (strong em u ol ul li p br a) are
-      allowed, all other tags are going to get stripped out by our application.</td>
-      <td>Text</td>
       <td>required</td>
     </tr>
     <tr>
@@ -176,36 +261,111 @@
       <td>optional</td>
     </tr>
     <tr>
+      <td>DescriptionHeadline</td>
+      <td>Headline summarizing the introductory description-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>Description</td>
+      <td>Description text of your job ad. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>required</td>
+    </tr>
+    <tr>
+      <td>CompanyDescriptionHeadline</td>
+      <td>Headline summarizing the company_description-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>CompanyDescription</td>
+      <td>Description text of your company. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>QualificationsHeadline</td>
+      <td>Headline summarizing the introductory qualifications-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>Qualifications</td>
+      <td>Text summarizing the requirements of the candiates. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>TasksHeadline</td>
+      <td>Headline summarizing the tasks-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>Tasks</td>
+      <td>Text summarizing the job tasks of the candiates. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>BenefitsHeadline</td>
+      <td>Headline summarizing the benefits-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>Benefits</td>
+      <td>Text summarizing the job benefits of the candiates. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>ContactHeadline</td>
+      <td>Headline summarizing the contact-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>Contact</td>
+      <td>Text summarizing the contact information for the candiates. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>VideoUrl</td>
+      <td>URL to embeddable video content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>HeaderImageUrl</td>
+      <td>URL to image that is being displayed at the top of the job ad. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>Color</td>
+      <td>Hex code for headline color. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
       <td>TraineeGefluester</td>
       <td>
-        <p>Allows co-publication of this job offer to our job board <a href="https://www.trainee-gefluester.de">trainee-gefluester.de</a> by supplying <code>true</code> or equivalently <code>1</code>. Note that a valid Trainee-Geflüster contract is required.</p>
-        <p>Contact your account manager for activation.</p>
+        <p>Allows co-publication a job offer on our job board TRAINEE-GEFLÜSTER by supplying <code>true</code> (valid TRAINEE-GEFLÜSTER contract required).</p>
+        <p>Contact your account manager if you are interested in this service.</p>
       </td>
       <td>String</td>
       <td>optional</td>
     </tr>
     <tr>
-      <td>CompanyDescription</td>
-      <td>Description text of the company this job offer belongs to.</td>
-      <td>Text</td>
-      <td>optional</td>
-    </tr>
-    <tr>
-      <td>UseResponsiveTemplate</td>
+      <td>PraktikumInfo</td>
       <td>
-        If you also submit an HTML representation of the job_offer (by submission of
-        <code>Link</code>) and if your HTML representation behaves responsive, you
-        can set this attribute to <code>true</code>. In this case the iframe serving
-        your HTML content will be displayed for mobile devices, too. If left out or
-        set to false, we will always render a text representation of the job offer.
+        <p>Allows co-publication a job offer on our job board PRAKTIKUM.INFO by supplying <code>true</code> (valid PRAKTIKUM.INFO contract required).</p>
+        <p>Contact your account manager if you are interested in this service.</p>
       </td>
-      <td>Boolean</td>
-      <td>optional</td>
-    </tr>
-    <tr>
-      <td>Height</td>
-      <td>Height of the iframe displaying the content of <code>Link</code> in px.</td>
-      <td>Integer</td>
+      <td>String</td>
       <td>optional</td>
     </tr>
   </tbody>

--- a/praktikum_info/absolventa_xml.md
+++ b/praktikum_info/absolventa_xml.md
@@ -1,37 +1,93 @@
 # Absolventa XML
 
 ```XML
+<?xml version="1.0" encoding="UTF-8"?>
 <job_offer>
+  <title>Praktikum Seefahrt (w/m/d)</title>
   <mode>premium</mode>
-  <title>Trainee Web Development (m/w)</title>
-  <external_url>https://example.com/jobs/1</external_url>
-  <description><![CDATA[<p>Basic HTML tags are allowed here</p>]]></description>
-  <started_at type="datetime">2017-01-03T00:00:00+02:00</started_at>
-  <ended_at type="datetime">2017-12-10T12:14:42+01:00</ended_at>
-  <!-- You need to either provide an URL or an email address for application. -->
-  <application_url>https://example.com/jobs/1/apply</application_url>
-  <application_email>application@absolventa.de</application_email>
-  <job_offer_locations>
-    <job_offer_location>
-      <street>Friedrichstraße 67</street>
-      <zip>10117</zip>
-      <city>Berlin</city>
-      <country>Deutschland</country>
-    </job_offer_location>
-    <job_offer_location>
-      <street>Greifswalder Straße 212</street>
-      <zip>10405</zip>
-      <city>Berlin</city>
-      <country>Deutschland</country>
-    </job_offer_location>
-  </job_offer_locations>
-  <contact_name>Rosi Beckers</contact_name>
-  <contact_email>rosi.beckers@absolventa.de</contact_email>
-  <contact_phone>030240483121</contact_name>
-  <contact_position>Leitung Personalwesen</contact_position>
-  <trainee_gefluester>true</trainee_gefluester>
+
+  <application_email>elaine.marley@absolventa.de</application_email>
+  <application_url><![CDATA[https://www.example.com/jobs/seefahrt/apply]]></application_url>
+  <started_at>2019-11-11T13:14:40+01:00</started_at>
+  <ended_at>2019-11-15T23:59:59+01:00</ended_at>
+
+  <city>Berlin</city>
+  <street>Friedrichstraße 67</street>
+  <zip>10318</zip>
+  <country>Deutschland</country>
+
+  <description_headline>Komm' an Bord!</description_headline>
+  <description>
+    <![CDATA[
+      <p>
+        Unser renormiertes Seefahrtsunternehmen heuert verlässlich und regelmäßig die besten
+        Seefrauen und -männer (w/m/d) östlich des Atlantiks an. Generationen von Seefahrtsexperten
+        haben ihre Karriere mit ersten nautischen Schritten in unserem Unternehmen gestartet.
+      </p>
+    ]]>
+  </description>
+
+  <qualifications_headline>Du bist mutig genug, in allen Ozeanen dieser Welt zu schwimmen?</qualifications_headline>
+  <qualifications>
+    <![CDATA[
+      <ul>
+        <li>Du kannst schwimmen (Seepferdchen notwendig)</li>
+        <li>Ein leichtes Schaukeln ist für dich kein Problem</li>
+      </ul>
+    ]]>
+  </qualifications>
+
+  <tasks_headline>Du kannst im Schlaf unter tosendem Sturm problemlos Segel setzen?</tasks_headline>
+  <tasks>
+    <![CDATA[
+      <ul>
+        <li>Du peppst die rauhen und kantigen Geschichten unserer weltweit verstreuten Mitarbeiter linguistisch gekonnt auf</li>
+        <li>Dein Instikt lässt dich spielerisch prüfbare Fakten von hanebüchenem Seemannsgarn unterscheiden</li>
+      </ul>
+    ]]>
+  </tasks>
+
+  <benefits_headline>Bestens ausgerüstet!</benefits_headline>
+  <benefits>
+    <![CDATA[
+      <ul>
+        <li>Reise zum Ende der Welt</li>
+        <li>Ein loyales Team</li>
+        <li>Remote first: Wir begrüßen ausdrücklich das eigenständige, asynchrone Arbeiten in entlegenen Gegenden</li>
+      </ul>
+    ]]>
+  </benefits>
+
+  <company_description_headline>Unser Geschäft ist kein Voodoo!</company_description_headline>
+  <company_description>
+    <![CDATA[
+      <p>Marley & Threepwood Ventures - Ihr Partner in Sachen Seefahrt- und Handelsbeziehungen</p>
+    ]]>
+  </company_description>
+
+  <video_url><![CDATA[https://api.example.com/videos/seemannsgarn]]></video_url>
+  <header_image_url><![CDATA[https://api.example.com/content/header_image.jpg]]></header_image_url>
+
+  <contact_headline>Frag' unsere Expertin Elaine!</contact_headline>
+  <contact>
+    <![CDATA[
+      <p>Elaine Marley</p>
+      <p>elaine.marley@absolventa.de</p>
+      <small>Senior Seefahrt-Personalmanagerin</small>
+    ]]>
+  </contact>
+
+  <color>#efefef</color>
+
+  <!-- These XML fields are deprecated -->
+  <external_url><![CDATA[https://www.example.com/jobs/seefahrt]]></external_url>
   <use_responsive_template>true</use_responsive_template>
-  <height>1200</height>
+  <height>1234</height>
+
+  <contact_name>Elaine Marley</contact_name>
+  <contact_email>elaine.marley@absolventa.de</contact_email>
+  <contact_phone>+49 0123456</contact_phone>
+  <contact_position>Recruiter</contact_position>
 </job_offer>
 ```
 
@@ -56,7 +112,7 @@
     <tr>
       <td>mode</td>
       <td>
-        Possible values: <code>standard</code> and <code>premium</code>.
+        Possible values: <code>standard</code>. <code>premium</code> and <code>premium_plus</code>.
         Defaults to <code>standard</code> if omitted.
         Cannot be changed after creation.
       </td>
@@ -70,12 +126,9 @@
       <td>required</td>
     </tr>
     <tr>
-      <td>external_url</td>
-      <td>
-        URL pointing to a HTML representation of your job offer. The HTML content of the <code>external_url</url> will be
-        displayed within an <code>iframe</code> element on our website.
-      </td>
-      <td>String</td>
+      <td>description_headline</td>
+      <td>Headline summarizing the introductory description-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
       <td>optional</td>
     </tr>
     <tr>
@@ -85,8 +138,80 @@
       <td>required</td>
     </tr>
     <tr>
+      <td>company_description_headline</td>
+      <td>Headline summarizing the company_description-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
       <td>company_description</td>
       <td>Description text of your company. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>qualifications_headline</td>
+      <td>Headline summarizing the introductory qualifications-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>qualifications</td>
+      <td>Text summarizing the requirements of the candiates. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>tasks_headline</td>
+      <td>Headline summarizing the tasks-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>tasks</td>
+      <td>Text summarizing the job tasks of the candiates. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>benefits_headline</td>
+      <td>Headline summarizing the benefits-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>benefits</td>
+      <td>Text summarizing the job benefits of the candiates. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>contact_headline</td>
+      <td>Headline summarizing the contact-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>contact</td>
+      <td>Text summarizing the contact information for the candiates. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>video_url</td>
+      <td>URL to embeddable video content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>header_image_url</td>
+      <td>URL to image that is being displayed at the top of the job ad. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>color</td>
+      <td>Hex code for headline color. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
       <td>Text</td>
       <td>optional</td>
     </tr>
@@ -102,7 +227,7 @@
     </tr>
     <tr>
       <td>apprenticeship_started_at</td>
-      <td>Date on which the apprenticeship will start</td>
+      <td>Date on which the apprenticeship will start. Only relevant for job ads targeted at https://www.azubi.de.</td>
       <td>Datetime</td>
       <td>optional</td>
     </tr>
@@ -113,25 +238,22 @@
       <td>optional</td>
     </tr>
     <tr>
-      <td>trainee_gefluester</td>
-      <td>
-        <p>Allows co-publication a job offer on our job board TRAINEE-GEFLÜSTER by supplying <code>true</code> (valid TRAINEE-GEFLÜSTER contract required).</p>
-        <p>Contact your account manager if you are interested in this service.</p>
-      </td>
+      <td>application_method</td>
+      <td>Info about the application method.</td>
       <td>String</td>
-      <td>optional</td>
+      <td>required (Either <code>email</code> or <code>url</code>)</td>
     </tr>
     <tr>
       <td>application_url</td>
       <td>URL pointing to the application online formular of the job offer.</td>
       <td>String</td>
-      <td>optional (You need to provide either an <code>application_url</code> or an <code>application_email</code>)</td>
+      <td>required (If application_method is set to <code>url</code>)</td>
     </tr>
     <tr>
       <td>application_email</td>
       <td>E-Mail address potential candidates shall send their applications to</td>
       <td>String</td>
-      <td>optional (You need to provide either an <code>application_url</code> or an <code>application_email</code>)</td>
+      <td>required (If application_method is set to <code>email</code>)</td>
     </tr>
     <tr>
       <td>job_offer_locations</td>
@@ -140,24 +262,6 @@
         has to include at least a <code>city</code> and a <code>zip</code> value.
       </td>
       <td>job_offer_location object</td>
-      <td>optional</td>
-    </tr>
-    <tr>
-      <td>use_responsive_template</td>
-      <td>
-        If you also submit an HTML representation of the job_offer (by submission of
-        <code>external_url</code>) and if your HTML representation behaves responsive, you
-        can set this attribute to <code>true</code>. In this case the iframe serving
-        your HTML content will be displayed for mobile devices, too. If left out or
-        set to false, we will always render a text representation of the job offer.
-      </td>
-      <td>Boolean</td>
-      <td>optional</td>
-    </tr>
-    <tr>
-      <td>height</td>
-      <td>Height of the iframe displaying the content of <code>external_url</code> in px.</td>
-      <td>Integer</td>
       <td>optional</td>
     </tr>
   </tbody>

--- a/praktikum_info/absolventa_xml.md
+++ b/praktikum_info/absolventa_xml.md
@@ -16,6 +16,21 @@
   <zip>10318</zip>
   <country>Deutschland</country>
 
+  <job_offer_locations>
+    <job_offer_location>
+      <city>Berlin</city>
+      <street>Greifswalder Straße 212</street>
+      <zip>10405</zip>
+      <country>Deutschland</country>
+    </job_offer_location>
+    <job_offer_location>
+      <city>Berlin</city>
+      <street>Oranienburger Straße 33</street>
+      <zip>10178</zip>
+      <country>Deutschland</country>
+    </job_offer_location>
+  </job_offer_locations>
+
   <description_headline>Komm' an Bord!</description_headline>
   <description>
     <![CDATA[

--- a/praktikum_info/hr_xml.md
+++ b/praktikum_info/hr_xml.md
@@ -27,11 +27,22 @@
       <PhysicalLocation>
         <PostalAddress>
           <CountryCode>Deutschland</CountryCode>
-          <PostalCode>10318</PostalCode>
+          <PostalCode>10117</PostalCode>
           <Municipality>Berlin</Municipality>
           <DeliveryAddress>
-            <StreetName>Friedrichstraße </StreetName>
+            <StreetName>Friedrichstraße</StreetName>
             <BuildingNumber>67</BuildingNumber>
+          </DeliveryAddress>
+        </PostalAddress>
+      </PhysicalLocation>
+      <PhysicalLocation>
+        <PostalAddress>
+          <CountryCode>Deutschland</CountryCode>
+          <PostalCode>10405</PostalCode>
+          <Municipality>Berlin</Municipality>
+          <DeliveryAddress>
+            <StreetName>Greifswalder Straße</StreetName>
+            <BuildingNumber>212</BuildingNumber>
           </DeliveryAddress>
         </PostalAddress>
       </PhysicalLocation>

--- a/praktikum_info/hr_xml.md
+++ b/praktikum_info/hr_xml.md
@@ -1,73 +1,165 @@
 # HR-XML
 
 ```XML
-<PositionOpening>
- <PositionPostings>
-   <PositionPosting>
-     <Id validFrom="2017-01-03" validTo="2017-12-10">
-       <!-- Note that the ID is auto-assigned when using the RESTful API -->
-       <IdValue>12345</IdValue>
-     </Id>
-     <Link><![CDATA[https://example.com/jobs/1]]></Link>
-   </PositionPosting>
- </PositionPostings>
- <PositionProfile>
-   <PositionDetail>
-     <PhysicalLocation>
-       <PostalAddress>
-         <CountryCode>DE</CountryCode>
-         <PostalCode>10405</PostalCode>
-         <Municipality>Berlin</Municipality>
-         <DeliveryAddress>
-           <StreetName>Greifswader Straße</StreetName>
-           <BuildingNumber>212</BuildingNumber>
-         </DeliveryAddress>
-       </PostalAddress>
-     </PhysicalLocation>
-     <PhysicalLocation>
-       <PostalAddress>
-         <CountryCode>DE</CountryCode>
-         <PostalCode>10117</PostalCode>
-         <Municipality>Berlin</Municipality>
-         <DeliveryAddress>
-           <StreetName>Friedrichsstraße</StreetName>
-           <BuildingNumber>67</BuildingNumber>
-         </DeliveryAddress>
-       </PostalAddress>
-     </PhysicalLocation>
-     <PositionTitle><![CDATA[Trainee Web Development (m/w)]]></PositionTitle>
-   </PositionDetail>
-   <FormattedPositionDescription>
-     <Name>Mode</Name>
-     <Value>standard</Value>
-   </FormattedPositionDescription>
-   <FormattedPositionDescription>
-     <Name>CompanyDescription</Name>
-     <Value><![CDATA[<p>Basic HTML tags are allowed here</p>]]></Value>
-   </FormattedPositionDescription>
-   <FormattedPositionDescription>
-     <Name>JobOfferDescription</Name>
-     <Value>
-       <![CDATA[<p>Basic HTML tags are allowed here</p>]]>
-     </Value>
-   </FormattedPositionDescription>
-   <FormattedPositionDescription>
-     <Name>TraineeGefluester</Name>
-     <Value>1</Value>
-   </FormattedPositionDescription>
-   <FormattedPositionDescription>
-     <Name>UseResponsiveTemplate</Name>
-     <Value>true</Value>
-   </FormattedPositionDescription>
-   <FormattedPositionDescription>
-     <Name>Height</Name>
-     <Value>1234</Value>
-   </FormattedPositionDescription>
-   <HowToApply>
-     <ApplicationMethod>
-       <InternetWebAddress><![CDATA[https://example.com/jobs/1/apply]]></InternetWebAddress>
-     </ApplicationMethod>
-   </HowToApply>
+<?xml version='1.0' encoding='utf-8' ?>
+<PositionOpening xmlns:datetime='http://exslt.org/dates-and-times' xmlns:ns1='http://ns.hr-xml.org' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns='http://ns.hr-xml.org' xsi:schemaLocation='http://ns.hr-xml.org/2_4/HR-XML-2_4/StandAlone/PositionOpening.xsd'>
+  <PositionRecordInfo>
+    <Id idOwner='Scho GbR'>
+      <IdValue>2448257</IdValue>
+    </Id>
+  </PositionRecordInfo>
+  <PositionPostings>
+    <PositionPosting>
+      <Id validFrom='2019-11-11' validTo='2019-11-15'>
+        <IdValue>2448257</IdValue>
+      </Id>
+      <Link><![CDATA[]]></Link>
+    </PositionPosting>
+  </PositionPostings>
+  <UserArea>
+  </UserArea>
+  <PositionProfile xml:lang='DE'>
+    <PositionDateInfo></PositionDateInfo>
+    <PositionDetail>
+      <Company>
+        <Name>Scho GbR</Name>
+      </Company>
+      <PhysicalLocation>
+        <PostalAddress>
+          <CountryCode>Deutschland</CountryCode>
+          <PostalCode>10318</PostalCode>
+          <Municipality>Berlin</Municipality>
+          <DeliveryAddress>
+            <StreetName>Friedrichstraße </StreetName>
+            <BuildingNumber>67</BuildingNumber>
+          </DeliveryAddress>
+        </PostalAddress>
+      </PhysicalLocation>
+      <PositionTitle><![CDATA[Praktikum Seefahrt (w/m/d)]]></PositionTitle>
+    </PositionDetail>
+    <FormattedPositionDescription>
+      <Name>Mode</Name>
+      <Value>premium</Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>JobOfferDescription</Name>
+      <Value><![CDATA[<p>
+            Unser renormiertes Seefahrtsunternehmen heuert verlässlich und regelmäßig die besten
+            Seefrauen und -männer (w/m/d) östlich des Atlantiks an. Generationen von Seefahrtsexperten
+            haben ihre Karriere mit ersten nautischen Schritten in unserem Unternehmen gestartet.
+      </p>]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>JobOfferQualifications</Name>
+      <Value><![CDATA[<ul>
+          <li>Du kannst schwimmen (Seepferdchen notwendig)</li>
+          <li>Ein leichtes Schaukeln ist für dich kein Problem</li>
+      </ul>]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>CompanyDescriptionHeadline</Name>
+      <Value><![CDATA[Unser Geschäft ist kein Voodoo!]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>CompanyDescription</Name>
+      <Value><![CDATA[<p>Marley & Threepwood Ventures - Ihr Partner in Sachen Seefahrt- und Handelsbeziehungen</p>]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>DescriptionHeadline</Name>
+      <Value><![CDATA[Komm' an Bord!]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>Description</Name>
+      <Value><![CDATA[<p>
+            Unser renormiertes Seefahrtsunternehmen heuert verlässlich und regelmäßig die besten
+            Seefrauen und -männer (w/m/d) östlich des Atlantiks an. Generationen von Seefahrtsexperten
+            haben ihre Karriere mit ersten nautischen Schritten in unserem Unternehmen gestartet.
+      </p>]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>Qualifications</Name>
+      <Value><![CDATA[Du bist mutig genug, in allen Ozeanen dieser Welt zu schwimmen?]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>Qualifications</Name>
+      <Value><![CDATA[<ul>
+          <li>Du kannst schwimmen (Seepferdchen notwendig)</li>
+          <li>Ein leichtes Schaukeln ist für dich kein Problem</li>
+      </ul>]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>TasksHeadline</Name>
+      <Value><![CDATA[Du kannst im Schlaf unter tosendem Sturm problemlos Segel setzen?]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>Tasks</Name>
+      <Value><![CDATA[<ul>
+          <li>Du peppst die rauhen und kantigen Geschichten unserer weltweit verstreuten Mitarbeiter linguistisch gekonnt auf</li>
+          <li>Dein Instikt lässt dich spielerisch prüfbare Fakten von hanebüchenem Seemannsgarn unterscheiden</li>
+      </ul>]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>BenefitsHeadline</Name>
+      <Value><![CDATA[Bestens ausgerüstet!]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>Benefits</Name>
+      <Value><![CDATA[
+        <ul>
+          <li>Reise zum Ende der Welt</li>
+          <li>Ein loyales Team</li>
+          <li>Remote first: Wir begrüßen ausdrücklich das eigenständige, asynchrone Arbeiten in entlegenen Gegenden</li>
+      </ul>
+      ]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>ContactHeadline</Name>
+      <Value><![CDATA[Frag' unsere Expertin Elaine!]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>Contact</Name>
+      <Value><![CDATA[<p>Elaine Marley</p>
+        <p>elaine.marley@absolventa.de</p>
+        <small>Senior Seefahrt-Personalmanagerin</small>]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>VideoUrl</Name>
+      <Value><![CDATA[https://api.example.com/videos/seemannsgarn]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>Height</Name>
+      <Value><![CDATA[]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>UseResponsiveTemplate</Name>
+      <Value><![CDATA[]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>Color</Name>
+      <Value><![CDATA[#efefef]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>HeaderImageUrl</Name>
+      <Value><![CDATA[https://api.example.com/content/header_image.jpg]]></Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>TraineeGefluester</Name>
+      <Value>false</Value>
+    </FormattedPositionDescription>
+    <FormattedPositionDescription>
+      <Name>PraktikumInfo</Name>
+      <Value>false</Value>
+    </FormattedPositionDescription>
+    <HowToApply>
+      <ApplicationMethod>
+        <InternetWebAddress><![CDATA[https://www.example.com/jobs/seefahrt/apply]]></InternetWebAddress>
+      </ApplicationMethod>
+    </HowToApply>
+    <HowToApply>
+      <ApplicationMethod>
+        <InternetWebAddress><![CDATA[https://www.example.com/jobs/seefahrt/apply]]></InternetWebAddress>
+      </ApplicationMethod>
+    </HowToApply>
   </PositionProfile>
 </PositionOpening>
 ```
@@ -104,13 +196,6 @@
       <td>PositionTitle</td>
       <td>Title.</td>
       <td>String</td>
-      <td>required</td>
-    </tr>
-    <tr>
-      <td>JobOfferDescription</td>
-      <td>Description Text. Basic HTML tags (strong em u ol ul li p br a) are
-      allowed, all other tags are going to get stripped out by our application.</td>
-      <td>Text</td>
       <td>required</td>
     </tr>
     <tr>
@@ -176,36 +261,111 @@
       <td>optional</td>
     </tr>
     <tr>
+      <td>DescriptionHeadline</td>
+      <td>Headline summarizing the introductory description-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>Description</td>
+      <td>Description text of your job ad. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>required</td>
+    </tr>
+    <tr>
+      <td>CompanyDescriptionHeadline</td>
+      <td>Headline summarizing the company_description-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>CompanyDescription</td>
+      <td>Description text of your company. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>QualificationsHeadline</td>
+      <td>Headline summarizing the introductory qualifications-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>Qualifications</td>
+      <td>Text summarizing the requirements of the candiates. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>TasksHeadline</td>
+      <td>Headline summarizing the tasks-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>Tasks</td>
+      <td>Text summarizing the job tasks of the candiates. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>BenefitsHeadline</td>
+      <td>Headline summarizing the benefits-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>Benefits</td>
+      <td>Text summarizing the job benefits of the candiates. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>ContactHeadline</td>
+      <td>Headline summarizing the contact-content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>Contact</td>
+      <td>Text summarizing the contact information for the candiates. Simple HTML tags such as <code>strong, em, u, ol, ul, li, p, br, a</code> are allowed.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>VideoUrl</td>
+      <td>URL to embeddable video content. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>HeaderImageUrl</td>
+      <td>URL to image that is being displayed at the top of the job ad. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
+      <td>Color</td>
+      <td>Hex code for headline color. Only allowed for <code>premium</code> or <code>premium_plus</code> job ads.</td>
+      <td>Text</td>
+      <td>optional</td>
+    </tr>
+    <tr>
       <td>TraineeGefluester</td>
       <td>
-        <p>Allows co-publication of this job offer to our job board <a href="https://www.trainee-gefluester.de">trainee-gefluester.de</a> by supplying <code>true</code> or equivalently <code>1</code>. Note that a valid Trainee-Geflüster contract is required.</p>
-        <p>Contact your account manager for activation.</p>
+        <p>Allows co-publication a job offer on our job board TRAINEE-GEFLÜSTER by supplying <code>true</code> (valid TRAINEE-GEFLÜSTER contract required).</p>
+        <p>Contact your account manager if you are interested in this service.</p>
       </td>
       <td>String</td>
       <td>optional</td>
     </tr>
     <tr>
-      <td>CompanyDescription</td>
-      <td>Description text of the company this job offer belongs to.</td>
-      <td>Text</td>
-      <td>optional</td>
-    </tr>
-    <tr>
-      <td>UseResponsiveTemplate</td>
+      <td>PraktikumInfo</td>
       <td>
-        If you also submit an HTML representation of the job_offer (by submission of
-        <code>Link</code>) and if your HTML representation behaves responsive, you
-        can set this attribute to <code>true</code>. In this case the iframe serving
-        your HTML content will be displayed for mobile devices, too. If left out or
-        set to false, we will always render a text representation of the job offer.
+        <p>Allows co-publication a job offer on our job board PRAKTIKUM.INFO by supplying <code>true</code> (valid PRAKTIKUM.INFO contract required).</p>
+        <p>Contact your account manager if you are interested in this service.</p>
       </td>
-      <td>Boolean</td>
-      <td>optional</td>
-    </tr>
-    <tr>
-      <td>Height</td>
-      <td>Height of the iframe displaying the content of <code>Link</code> in px.</td>
-      <td>Integer</td>
+      <td>String</td>
       <td>optional</td>
     </tr>
   </tbody>


### PR DESCRIPTION
# »Performance Design« - New semantics for our job offer data structure

As time goes by, the data structures that underlie the RESTful API systems of [Absolventa](https://www.absolventa.de) and [Praktikum.info](https://www.praktikum.info) constantly evolve. Recently, we've reshaped them again and these changes affect the capabilities and use cases for our RESTful APIs. By this PR to our documentation, we'd like to give more information on that change process.

## Attributes that are still supported until March 31, 2020 - but are marked deprecated now

Up to now, there was the possibility of displaying external HTML content for a job offer within an `<iframe>` div element on our website. That is, when you have posted a `<job_offer>` containing an `<external_url>` node, we are displaying the HTML content of the URL you have submitted within that `<external_url>` node in an `<iframe>` as represenation of that job ad.  

We are sunsetting this feature for the RESTful API by the end of March, 2020. Since the attributes `<height>` and `<use_responsive_template>` are exclusively related to this feature, these attributes, `<height>` and `<use_responsive_template>`, are marked as deprecated, too.

In short:

The attributes `external_url`, `height`and `use_responsive_template` are going to get removed and are supported until March 2020. By April 2020, the RESTful API will ignore them for incoming POST and PUT requests. 

## New attributes

Instead of a complete HTML representation loaded by an external URL, we nowadays offer a rich set of semantic attributes to get filled for your job offers. Here's a list of them:

* description (not new)
* description_headline
* qualifications (not new)
* qualifications_headline
* company_description (not new)
* company_description_headline
* benefits
* benefits_headline
* tasks
* tasks_headline
* contact
* contact_headline
* color (determines color of all headlines) 
* video_url
* header_image_url

However, filling these attributes is additional and optional - some of them are even restricted for premium job ads only. This PR updates the documentation properly that you have a reference.  Please consult our XML examples for more details.

## What else is changing?

* Some of our attributes, i.e. `description` and `qualifications`, allow basic HTML tags as content. Instead of encoding such content by using HTML entities, we are now making use of [CDATA tags](https://de.wikipedia.org/wiki/CDATA) to represent them within the XML structure. We strongly believe this is increases stability and readability as no decoding process is necessary!

## FAQ

#### Q: We're maintaining a software that makes use of your RESTful API system. Do I need to implement changes immediately? 🙀

_There's no immediate need to change your systems for posting and updating job offer records_ . All HTTP POST and HTTP PUT requests still accept your XML markup as before this PR, but all GET requests you initiate to our systems will respond _with the new markup_.

#### Q: Does this affect both data formats, AbsolventaXML and HR-XML?

Yes, this change affects both of them.

#### Q: Is there a change to the endpoints itself?

No, the endpoints stay invariant!

#### Q: You missed something and our systems are broken now 😖 What shall I do?



In case of questions or problems, do not hesitate and reach out to our team via [email 📫](mailto:api@absolventa.de) - we are going to assist and support you! ⛑ 