### PR TITLE
Drop some runtime fields and provide additional explanations

### DIFF
--- a/absolventa/absolventa_xml.md
+++ b/absolventa/absolventa_xml.md
@@ -9,7 +9,6 @@
   <application_email>elaine.marley@absolventa.de</application_email>
   <application_url><![CDATA[https://www.example.com/jobs/seefahrt/apply]]></application_url>
   <started_at>2019-11-11T13:14:40+01:00</started_at>
-  <ended_at>2019-11-15T23:59:59+01:00</ended_at>
 
   <!--
     If the at least one of nodes <city> or <zip> (and optionally street and country) are given
@@ -259,16 +258,6 @@ attributes: <code>href, class, target</code>. All other attributes will get stri
       <td>Date on which the apprenticeship will start. Only relevant for job ads targeted at https://www.azubi.de.</td>
       <td>Datetime</td>
       <td>optional</td>
-    </tr>
-    <tr>
-      <td>ended_at</td>
-      <td>
-        Date on which the job offer stops being published to our platform. If not specified, we will
-        compute and assign the latest point in time that is allowed w.r.t to your contract.
-        Also note that updating the ended_at value is possibly restricted.
-      </td>
-      <td>Datetime</td>
-      <td>optional - we will auto-assign this value if left out and determine the latest possible value.</td>
     </tr>
     <tr>
       <td>application_method</td>

--- a/absolventa/hr_xml.md
+++ b/absolventa/hr_xml.md
@@ -10,7 +10,7 @@
   </PositionRecordInfo>
   <PositionPostings>
     <PositionPosting>
-      <Id validFrom='2019-11-11' validTo='2019-11-15'>
+      <Id validFrom='2019-11-11'>
         <IdValue>2448257</IdValue>
       </Id>
       <Link><![CDATA[]]></Link>
@@ -188,13 +188,7 @@
       <td>Datetime</td>
       <td>optional</td>
     </tr>
-    <tr>
-      <td>PositionPosting - ValidTo</td>
-      <td>Date on which the job offer stops being published to our platform.</td>
-      <td>Datetime</td>
-      <td>optional</td>
-    </tr>
-    <tr>
+   <tr>
       <td>CountryCode</td>
       <td>ISO code of the country of the location the job refers to.</td>
       <td>String</td>

--- a/absolventa/pull_api.md
+++ b/absolventa/pull_api.md
@@ -9,6 +9,9 @@ Once a connection is established, we regularly (usually once a day) parse the pr
   <li>Job offers present in the feed that are already published on our platform will be updated according to the provided information.</li>
   <li>Job offers not present in the feed anymore but published on our platform will be quit.</li>
 </ul>
+Note that job offers can only be published if the booked contract allows for it. If a job offer is still present in a feed
+after its runtime as specified by the contract is over, it will be treated as a new job offer (and hence get newly published
+if the contract still allows for it).
 
 ### Sample XML format
 

--- a/absolventa/pull_api.md
+++ b/absolventa/pull_api.md
@@ -2,7 +2,13 @@
 
 Our application is able to process data streams served via HTTP of different format. If you already have your
 jobs wrapped into a custom data stream ready to read via HTTP, please [contact our team](mailto:api@absolventa.de) to verify
-if we can handle it.
+if we can handle it. <br>
+Once a connection is established, we regularly (usually once a day) parse the provided feed and adjust the published job offers accordingly:
+<ul>
+  <li>Job offers present in the feed that are not yet published on our platform will be published.</li>
+  <li>Job offers present in the feed that are already published on our platform will be updated according to the provided information.</li>
+  <li>Job offers not present in the feed anymore but published on our platform will be quit.</li>
+</ul>
 
 ### Sample XML format
 

--- a/absolventa/pull_api.md
+++ b/absolventa/pull_api.md
@@ -18,8 +18,6 @@ data in this format, we can immediately configure a connection:
 
     <application_email>elaine.marley@absolventa.de</application_email>
     <application_url><![CDATA[https://www.example.com/jobs/seefahrt/apply]]></application_url>
-    <started_at>2019-11-11T13:14:40+01:00</started_at>
-    <ended_at>2019-11-15T23:59:59+01:00</ended_at>
 
     <job_offer_locations>
       <job_offer_location>
@@ -224,22 +222,6 @@ data in this format, we can immediately configure a connection:
       <td>color</td>
       <td>Hex code for headline color. Only allowed for <code>premium</code> job ads.</td>
       <td>Text</td>
-      <td>optional</td>
-    </tr>
-    <tr>
-      <td>started_at</td>
-      <td>
-        Date the job offer starts being published to our platform. Note that once the job offer has
-        been published this field cannot be edited any longer. If left out, we immediately publish your
-        job offer.
-      </td>
-      <td>Datetime</td>
-      <td>optional</td>
-    </tr>
-    <tr>
-      <td>ended_at</td>
-      <td>Date on which the job offer stops being published to our platform.</td>
-      <td>Datetime</td>
       <td>optional</td>
     </tr>
     <tr>

--- a/absolventa/pull_api.md
+++ b/absolventa/pull_api.md
@@ -117,7 +117,7 @@ data in this format, we can immediately configure a connection:
   <tbody>
     <tr>
       <td>external_id</td>
-      <td>Your internal identifier of the record</td>
+      <td>Your internal identifier of the record. Has to be unique among published records and is not allowed to change.</td>
       <td>String</td>
       <td>required</td>
     </tr>

--- a/absolventa/restful_api.md
+++ b/absolventa/restful_api.md
@@ -436,15 +436,6 @@ curl -i -X PUT https://www.absolventa.de/api/r/hrxml/job_offers/12345.xml \
 ### End a job offer
 
 If you want to unpublish a job offer before its natural end of runtime, you can perform a PUT request to the corresponding endpoint as shown below.
-By this endpoint you can also edit the current end date to a new value. To achieve this, wrap your requested datetime wrapped in XML like this and send it
-as data attached to your request:
-
-<code>
-  &ltended_at&gt2019-01-01&lt/ended_at&gt
-</code>
-
-Note that your requested date has to
-be before the job offer's current value of ended_at.
 
 <table>
   <tbody>
@@ -461,17 +452,11 @@ be before the job offer's current value of ended_at.
   </tbody>
 </table>
 
-#### Examples
+#### Example
 
 ```
 curl -X PUT -H 'Accept: application/xml' \
             -H 'Content-Type: application/xml'&#x000A; \
             -u 28a622e8ea6665433729932112d1d9cc:X \
-            https://www.absolventa.de/api/r/job_offers/12345/quit.xml
-
-curl -X PUT -H 'Accept: application/xml' \
-            -H 'Content-Type: application/xml'&#x000A; \
-            -u 28a622e8ea6665433729932112d1d9cc:X \
-            -d '<ended_at>2019-07-28T14:27:31+02:00</ended_at>' \
             https://www.absolventa.de/api/r/job_offers/12345/quit.xml
 ```

--- a/azubi/pull_api.md
+++ b/azubi/pull_api.md
@@ -9,6 +9,9 @@ Once a connection is established, we regularly (usually once a day) parse the pr
   <li>Job offers present in the feed that are already published on our platform will be updated according to the provided information.</li>
   <li>Job offers not present in the feed anymore but published on our platform will be quit.</li>
 </ul>
+Note that job offers can only be published if the booked contract allows for it. If a job offer is still present in a feed
+after its runtime as specified by the contract is over, it will be treated as a new job offer (and hence get newly published
+if the contract still allows for it).
 
 ### Sample Data Format
 

--- a/azubi/pull_api.md
+++ b/azubi/pull_api.md
@@ -131,7 +131,7 @@ data in this format, we can immediately configure a connection:
   <tbody>
     <tr>
       <td>external_id</td>
-      <td>Your internal identifier of the record</td>
+      <td>Your internal identifier of the record. Has to be unique among published records and is not allowed to change.</td>
       <td>String</td>
       <td>required</td>
     </tr>

--- a/azubi/pull_api.md
+++ b/azubi/pull_api.md
@@ -18,8 +18,6 @@ data in this format, we can immediately configure a connection:
 
     <application_email>elaine.marley@absolventa.de</application_email>
     <application_url><![CDATA[https://www.example.com/jobs/seefahrt/apply]]></application_url>
-    <started_at>2019-11-11T13:14:40+01:00</started_at>
-    <ended_at>2019-11-15T23:59:59+01:00</ended_at>
 
     <minimal_degree>certificate</minimal_degree>
     <duration>36</duration>
@@ -241,24 +239,8 @@ data in this format, we can immediately configure a connection:
       <td>optional</td>
     </tr>
     <tr>
-      <td>started_at</td>
-      <td>
-        Date the job offer starts being published to our platform. Note that once the job offer has
-        been published this field cannot be edited any longer. If left out, we immediately publish your
-        job offer.
-      </td>
-      <td>Datetime</td>
-      <td>optional</td>
-    </tr>
-    <tr>
       <td>apprenticeship_started_at</td>
       <td>Date on which the apprenticeship will start. Only relevant for job ads targeted at https://www.azubi.de.</td>
-      <td>Datetime</td>
-      <td>optional</td>
-    </tr>
-    <tr>
-      <td>ended_at</td>
-      <td>Date on which the job offer stops being published to our platform.</td>
       <td>Datetime</td>
       <td>optional</td>
     </tr>

--- a/azubi/pull_api.md
+++ b/azubi/pull_api.md
@@ -2,7 +2,13 @@
 
 Our application is able to process data streams served via HTTP of different format. If you already have your
 jobs wrapped into a custom data stream ready to read via HTTP, please [contact our team](mailto:api@absolventa.de) to verify
-if we can handle it.
+if we can handle it. <br>
+Once a connection is established, we regularly (usually once a day) parse the provided feed and adjust the published job offers accordingly:
+<ul>
+  <li>Job offers present in the feed that are not yet published on our platform will be published.</li>
+  <li>Job offers present in the feed that are already published on our platform will be updated according to the provided information.</li>
+  <li>Job offers not present in the feed anymore but published on our platform will be quit.</li>
+</ul>
 
 ### Sample Data Format
 

--- a/praktikum_info/absolventa_xml.md
+++ b/praktikum_info/absolventa_xml.md
@@ -9,7 +9,6 @@
   <application_email>elaine.marley@absolventa.de</application_email>
   <application_url><![CDATA[https://www.example.com/jobs/seefahrt/apply]]></application_url>
   <started_at>2019-11-11T13:14:40+01:00</started_at>
-  <ended_at>2019-11-15T23:59:59+01:00</ended_at>
 
   <!--
     If the at least one of nodes <city> or <zip> (and optionally street and country) are given
@@ -259,16 +258,6 @@ attributes: <code>href, class, target</code>. All other attributes will get stri
       <td>Date on which the apprenticeship will start. Only relevant for job ads targeted at https://www.azubi.de.</td>
       <td>Datetime</td>
       <td>optional</td>
-    </tr>
-    <tr>
-      <td>ended_at</td>
-      <td>
-        Date on which the job offer stops being published to our platform. If not specified, we will
-        compute and assign the latest point in time that is allowed w.r.t to your contract.
-        Also note that updating the ended_at value is possibly restricted.
-      </td>
-      <td>Datetime</td>
-      <td>optional - we will auto-assign this value if left out and determine the latest possible value.</td>
     </tr>
     <tr>
       <td>application_method</td>

--- a/praktikum_info/hr_xml.md
+++ b/praktikum_info/hr_xml.md
@@ -10,7 +10,7 @@
   </PositionRecordInfo>
   <PositionPostings>
     <PositionPosting>
-      <Id validFrom='2019-11-11' validTo='2019-11-15'>
+      <Id validFrom='2019-11-11'>
         <IdValue>2448257</IdValue>
       </Id>
       <Link><![CDATA[]]></Link>
@@ -185,12 +185,6 @@
         been published this field cannot be edited any longer. If left out, we immediately publish your
         job offer.
       </td>
-      <td>Datetime</td>
-      <td>optional</td>
-    </tr>
-    <tr>
-      <td>PositionPosting - ValidTo</td>
-      <td>Date on which the job offer stops being published to our platform.</td>
       <td>Datetime</td>
       <td>optional</td>
     </tr>

--- a/praktikum_info/pull_api.md
+++ b/praktikum_info/pull_api.md
@@ -18,8 +18,6 @@ data in this format, we can immediately configure a connection:
 
     <application_email>elaine.marley@absolventa.de</application_email>
     <application_url><![CDATA[https://www.example.com/jobs/seefahrt/apply]]></application_url>
-    <started_at>2019-11-11T13:14:40+01:00</started_at>
-    <ended_at>2019-11-15T23:59:59+01:00</ended_at>
 
     <job_offer_locations>
       <job_offer_location>
@@ -225,22 +223,6 @@ data in this format, we can immediately configure a connection:
       <td>color</td>
       <td>Hex code for headline color. Only allowed for <code>premium</code> job ads.</td>
       <td>Text</td>
-      <td>optional</td>
-    </tr>
-    <tr>
-      <td>started_at</td>
-      <td>
-        Date the job offer starts being published to our platform. Note that once the job offer has
-        been published this field cannot be edited any longer. If left out, we immediately publish your
-        job offer.
-      </td>
-      <td>Datetime</td>
-      <td>optional</td>
-    </tr>
-    <tr>
-      <td>ended_at</td>
-      <td>Date on which the job offer stops being published to our platform.</td>
-      <td>Datetime</td>
       <td>optional</td>
     </tr>
     <tr>

--- a/praktikum_info/pull_api.md
+++ b/praktikum_info/pull_api.md
@@ -118,7 +118,7 @@ data in this format, we can immediately configure a connection:
   <tbody>
     <tr>
       <td>external_id</td>
-      <td>Your internal identifier of the record</td>
+      <td>Your internal identifier of the record. Has to be unique among published records and is not allowed to change.</td>
       <td>String</td>
       <td>required</td>
     </tr>

--- a/praktikum_info/pull_api.md
+++ b/praktikum_info/pull_api.md
@@ -9,6 +9,9 @@ Once a connection is established, we regularly (usually once a day) parse the pr
   <li>Job offers present in the feed that are already published on our platform will be updated according to the provided information.</li>
   <li>Job offers not present in the feed anymore but published on our platform will be quit.</li>
 </ul>
+Note that job offers can only be published if the booked contract allows for it. If a job offer is still present in a feed
+after its runtime as specified by the contract is over, it will be treated as a new job offer (and hence get newly published
+if the contract still allows for it).
 
 ### Sample XML format
 

--- a/praktikum_info/pull_api.md
+++ b/praktikum_info/pull_api.md
@@ -2,7 +2,13 @@
 
 Our application is able to process data streams served via HTTP of different format. If you already have your
 jobs wrapped into a custom data stream ready to read via HTTP, please [contact our team](mailto:api@absolventa.de) to verify
-if we can handle it.
+if we can handle it. <br>
+Once a connection is established, we regularly (usually once a day) parse the provided feed and adjust the published job offers accordingly:
+<ul>
+  <li>Job offers present in the feed that are not yet published on our platform will be published.</li>
+  <li>Job offers present in the feed that are already published on our platform will be updated according to the provided information.</li>
+  <li>Job offers not present in the feed anymore but published on our platform will be quit.</li>
+</ul>
 
 ### Sample XML format
 

--- a/praktikum_info/restful_api.md
+++ b/praktikum_info/restful_api.md
@@ -394,15 +394,6 @@ curl -i -X PUT -H 'Accept: application/xml' -H 'Content-Type: application/xml'
 ### End a job offer
 
 If you want to unpublish a job offer before its natural end of runtime, you can perform a PUT request to the corresponding endpoint as shown below.
-By this endpoint you can also edit the current end date to a new value. To achieve this, wrap your requested datetime wrapped in XML like this and send it
-as data attached to your request:
-
-<code>
-  &ltended_at&gt2019-01-01&lt/ended_at&gt
-</code>
-
-Note that your requested date has to
-be before the job offer's current value of ended_at.
 
 <table>
   <tbody>
@@ -419,17 +410,11 @@ be before the job offer's current value of ended_at.
   </tbody>
 </table>
 
-#### Examples
+#### Example
 
 ```
 curl -X PUT -H 'Accept: application/xml'
             -H 'Content-Type: application/xml'&#x000A;
             -u 28a622e8ea6665433729932112d1d9cc:X
-            https://www.praktikum.info/api/c/job_offers/12345/quit.xml
-
-curl -X PUT -H 'Accept: application/xml'
-            -H 'Content-Type: application/xml'&#x000A;
-            -u 28a622e8ea6665433729932112d1d9cc:X
-            -d '<ended_at>2019-07-28T14:27:31+02:00</ended_at>'
             https://www.praktikum.info/api/c/job_offers/12345/quit.xml
 ```

--- a/trainee_gefluester/pull_api.md
+++ b/trainee_gefluester/pull_api.md
@@ -118,7 +118,7 @@ data in this format, we can immediately configure a connection:
   <tbody>
     <tr>
       <td>external_id</td>
-      <td>Your internal identifier of the record</td>
+      <td>Your internal identifier of the record. Has to be unique among published records and is not allowed to change.</td>
       <td>String</td>
       <td>required</td>
     </tr>

--- a/trainee_gefluester/pull_api.md
+++ b/trainee_gefluester/pull_api.md
@@ -9,6 +9,9 @@ Once a connection is established, we regularly (usually once a day) parse the pr
   <li>Job offers present in the feed that are already published on our platform will be updated according to the provided information.</li>
   <li>Job offers not present in the feed anymore but published on our platform will be quit.</li>
 </ul>
+Note that job offers can only be published if the booked contract allows for it. If a job offer is still present in a feed
+after its runtime as specified by the contract is over, it will be treated as a new job offer (and hence get newly published
+if the contract still allows for it).
 
 ### Sample XML format
 

--- a/trainee_gefluester/pull_api.md
+++ b/trainee_gefluester/pull_api.md
@@ -2,7 +2,13 @@
 
 Our application is able to process data streams served via HTTP of different format. If you already have your
 jobs wrapped into a custom data stream ready to read via HTTP, please [contact our team](mailto:api@absolventa.de) to verify
-if we can handle it.
+if we can handle it. <br>
+Once a connection is established, we regularly (usually once a day) parse the provided feed and adjust the published job offers accordingly:
+<ul>
+  <li>Job offers present in the feed that are not yet published on our platform will be published.</li>
+  <li>Job offers present in the feed that are already published on our platform will be updated according to the provided information.</li>
+  <li>Job offers not present in the feed anymore but published on our platform will be quit.</li>
+</ul>
 
 ### Sample XML format
 

--- a/trainee_gefluester/pull_api.md
+++ b/trainee_gefluester/pull_api.md
@@ -18,8 +18,6 @@ data in this format, we can immediately configure a connection:
 
     <application_email>elaine.marley@absolventa.de</application_email>
     <application_url><![CDATA[https://www.example.com/jobs/seefahrt/apply]]></application_url>
-    <started_at>2020-11-11T13:14:40+01:00</started_at>
-    <ended_at>2020-11-15T23:59:59+01:00</ended_at>
 
     <job_offer_locations>
       <job_offer_location>
@@ -225,22 +223,6 @@ data in this format, we can immediately configure a connection:
       <td>color</td>
       <td>Hex code for headline color. Only allowed for <code>premium</code> job ads.</td>
       <td>Text</td>
-      <td>optional</td>
-    </tr>
-    <tr>
-      <td>started_at</td>
-      <td>
-        Date the job offer starts being published to our platform. Note that once the job offer has
-        been published this field cannot be edited any longer. If left out, we immediately publish your
-        job offer.
-      </td>
-      <td>Datetime</td>
-      <td>optional</td>
-    </tr>
-    <tr>
-      <td>ended_at</td>
-      <td>Date on which the job offer stops being published to our platform.</td>
-      <td>Datetime</td>
       <td>optional</td>
     </tr>
     <tr>


### PR DESCRIPTION
This PR
- removes documentation on setting `ended_at` (REST) and `started_at` + `ended_at` (Pull), since this is not supported anymore. This is because our product logic as well as the Pull API's inherent logic conflict with the explicit setting of this fields (also see next point).
- adds some general explanation regarding the Pull API's logic. This also clarifies how a job offer's runtime can be managed using the Pull API.
- clarifies what requirements the `external_id` needs to meet.